### PR TITLE
Add thread ids from reactions to the cache

### DIFF
--- a/matterircd_complete.pl
+++ b/matterircd_complete.pl
@@ -389,12 +389,6 @@ sub cache_msgthreadid {
         }
     }
 
-    # We also want to ignore reactions as we can't reply to those
-    # directly if they're to a message in a thread.
-    if ($msg =~ /(?:added|removed) reaction:/) {
-        return;
-    }
-
     # Mattermost message/thread IDs.
     if ($msg =~ /\[(?:->|↪)?\@\@([0-9a-z]{26})(?:,\@\@([0-9a-z]{26}))?\]/) {
         my $msgthreadid = $1;


### PR DESCRIPTION
As it seems they're using the proper thread id now.