### PR TITLE
Update post ID colours in addition to thread

### DIFF
--- a/matterircd_complete.pl
+++ b/matterircd_complete.pl
@@ -254,8 +254,12 @@ sub update_msgthreadid {
     return unless $msgthreadid;
 
     my $thread_color = Irssi::settings_get_int('matterircd_complete_thread_id_color');
+    my $post_color = '';
     if ($thread_color == -1) {
         $thread_color = thread_color($msgthreadid);
+        if ($msgpostid ne '') {
+            $post_color = thread_color($msgpostid);
+        }
     } else {
         $thread_color = "\x03${thread_color}";
     }
@@ -283,6 +287,8 @@ sub update_msgthreadid {
     }
     if ($msgpostid eq '') {
         $msg =~ s/\@\@PLACEHOLDER\@\@/${thread_color}[${prefix}${msgthreadid}]\x0f/;
+    } elsif ($post_color ne '') {
+        $msg =~ s/\@\@PLACEHOLDER\@\@/${thread_color}[${prefix}${msgthreadid},${post_color}${msgpostid}${thread_color}]\x0f/;
     } else {
         $msg =~ s/\@\@PLACEHOLDER\@\@/${thread_color}[${prefix}${msgthreadid},${msgpostid}]\x0f/;
     }

--- a/matterircd_complete.pl
+++ b/matterircd_complete.pl
@@ -334,7 +334,7 @@ sub cache_store {
 
 
 my %MSGTHREADID_CACHE;
-Irssi::settings_add_int('matterircd_complete', 'matterircd_complete_message_thread_id_cache_size', 50);
+Irssi::settings_add_int('matterircd_complete', 'matterircd_complete_message_thread_id_cache_size', 32);
 sub cmd_matterircd_complete_msgthreadid_cache_dump {
     my ($data, $server, $wi) = @_;
 
@@ -668,7 +668,7 @@ Irssi::signal_add_last('message own_private', 'signal_message_own_private');
 
 
 my %NICKNAMES_CACHE;
-Irssi::settings_add_int('matterircd_complete', 'matterircd_complete_nick_cache_size', 20);
+Irssi::settings_add_int('matterircd_complete', 'matterircd_complete_nick_cache_size', 16);
 sub cmd_matterircd_complete_nick_cache_dump {
     my ($data, $server, $wi) = @_;
 
@@ -950,7 +950,7 @@ Irssi::signal_add_last('gui key pressed', 'signal_gui_key_pressed_nicks');
 
 
 my %REPLIED_CACHE;
-Irssi::settings_add_int('matterircd_complete', 'matterircd_complete_replied_cache_size', 50);
+Irssi::settings_add_int('matterircd_complete', 'matterircd_complete_replied_cache_size', 32);
 sub cmd_matterircd_complete_replied_cache_dump {
     my ($data, $server, $wi) = @_;
 


### PR DESCRIPTION
This makes it easier to visually tell when reactions are added to specific posts in the thread conversation